### PR TITLE
Implement LUNARA luxury landing page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <title>LUNARA</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,95 @@
-.App {
+/* Global styles for the LUNARA landing page */
+.app {
   text-align: center;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+.navbar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: flex-start;
+  font-family: 'Playfair Display', serif;
+  font-size: 1.25rem;
+  color: #fff;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
+.logo {
+  font-weight: bold;
 }
 
-.App-header {
-  background-color: #282c34;
+.hero {
+  position: relative;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  padding: 2rem;
+  overflow: hidden;
 }
 
-.App-link {
-  color: #61dafb;
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: url('https://images.unsplash.com/photo-1526045612212-70caf35c14df?auto=format&fit=crop&w=1650&q=80');
+  background-size: cover;
+  background-position: center;
+  opacity: 0.2;
+  pointer-events: none;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.15) 1px, transparent 1px);
+  background-size: 3px 3px;
+  opacity: 0.2;
+  pointer-events: none;
+}
+
+.hero h1 {
+  position: relative;
+  margin: 0;
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2rem, 6vw, 4rem);
+  color: #ffffff;
+}
+
+.hero p {
+  position: relative;
+  max-width: 600px;
+  color: #cccccc;
+  margin: 1rem 0 2rem;
+  line-height: 1.6;
+}
+
+.cta-button {
+  position: relative;
+  display: inline-block;
+  padding: 0.75rem 2rem;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #000000;
+  text-decoration: none;
+  font-weight: bold;
+  transition: box-shadow 0.3s ease;
+}
+
+.cta-button:hover {
+  box-shadow: 0 0 10px rgba(255, 215, 0, 0.6), 0 0 20px rgba(255, 215, 0, 0.4);
+}
+
+@media (max-width: 600px) {
+  .navbar {
+    padding: 1rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .cta-button {
+    padding: 0.5rem 1.5rem;
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,23 +1,21 @@
-import logo from './logo.svg';
 import './App.css';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
+    <div className="app">
+      <nav className="navbar">
+        <span className="logo">LUNARA</span>
+      </nav>
+      <section className="hero">
+        <h1>Futuristic Elegance</h1>
         <p>
-          Edit <code>src/App.js</code> and save to reload.
+          Explore celestial-grade electronics designed for a new dimension of
+          living.
         </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
+        <a href="#" className="cta-button">
+          Shop Now
         </a>
-      </header>
+      </section>
     </div>
   );
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders main headline', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/futuristic elegance/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,8 @@
+
 body {
   margin: 0;
+  background: #000;
+  color: #fff;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;


### PR DESCRIPTION
## Summary
- load `Playfair Display` font and rename site to LUNARA
- add full-screen hero layout with navbar, headline, subheading and CTA button
- implement celestial styling with faded gadget background and starfield
- ensure body uses dark theme
- update tests for new headline

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6885d1acd12083228a3b49ad009a5687